### PR TITLE
Some tricks that are useful to know

### DIFF
--- a/SymmetricProject.lean
+++ b/SymmetricProject.lean
@@ -4,5 +4,4 @@ import SymmetricProject.esymm_generating
 import SymmetricProject.roots_deriv
 import SymmetricProject.attainable
 
-/-- The purpose of this project is to formalize the results in https://arxiv.org/abs/2310.05328 , hereafter referred to as "the paper". -/
-
+/- The purpose of this project is to formalize the results in https://arxiv.org/abs/2310.05328 , hereafter referred to as "the paper". -/

--- a/SymmetricProject/binomial.lean
+++ b/SymmetricProject/binomial.lean
@@ -4,11 +4,11 @@ import Mathlib.Data.Finset.Fin
 import Mathlib.Data.Fintype.Fin
 import Init.Data.Nat.Basic
 
--- basic facts about the set "set_binom n k" (or $\binom{[n]}{k}$) of k-element subsets of $[n] = \{0, \dots, n-1\}$.
+/-! Basic facts about the set "set_binom n k" (or $\binom{[n]}{k}$) of k-element subsets of $[n] = \{0, \dots, n-1\}$. -/
 
 open Finset
 
--- "set_binom n k" is the set $\binom{[n]}{k}$) of k-element subsets of $[n] = \{0, \dots, n-1\}$
+/-- `set_binom n k` is the set $\binom{[n]}{k}$ of k-element subsets of $[n] = \{0, \dots, n-1\}$ -/
 def set_binom (n : ℕ) (k : ℕ) : Finset (Finset ℕ) :=
   powersetLen k (range n)
 
@@ -23,7 +23,7 @@ theorem Finset.mapEmbedding_card : (Finset.mapEmbedding f s).card = s.card := by
 
 @[simp]
 theorem Finset.mem_mapEmbedding : x ∈ Finset.mapEmbedding f s ↔ ∃ y ∈ s, f y = x :=
-  Finset.mem_map 
+  Finset.mem_map
 
 abbrev Finset.mapFinVal (n : ℕ) : Finset (Fin n) ↪ Finset ℕ := (Finset.mapEmbedding Fin.valEmbedding).toEmbedding
 
@@ -40,11 +40,11 @@ example : Finset.map (Finset.mapFinVal n) (set_binom' n k) = set_binom n k := by
     simp [c]
     intro a h
     rw [Finset.mem_mapEmbedding] at h
-    rcases h with ⟨y, _, rfl⟩ 
+    rcases h with ⟨y, _, rfl⟩
     simp
-  · rintro ⟨h, rfl⟩ 
-    refine ⟨Finset.attachFin s ?_, ?_⟩ 
-    · intro m w 
+  · rintro ⟨h, rfl⟩
+    refine ⟨Finset.attachFin s ?_, ?_⟩
+    · intro m w
       specialize h w
       simp_all
     simp? says simp only [card_attachFin, true_and]
@@ -52,60 +52,52 @@ example : Finset.map (Finset.mapFinVal n) (set_binom' n k) = set_binom n k := by
     rw [Finset.mem_mapEmbedding] -- why does this not work by simp?!
     simp? says simp only [mem_attachFin, Fin.valEmbedding_apply]
     constructor
-    · rintro ⟨y, m, rfl⟩  
+    · rintro ⟨y, m, rfl⟩
       assumption
     · intro mem
       specialize h mem
-      use ⟨m, by simpa using h⟩ 
+      use ⟨m, by simpa using h⟩
 
 -- shorter proof provided by Arend Mellendiijk
 example : Finset.map (Finset.mapFinVal n) (set_binom' n k) = set_binom n k := by
   rw[set_binom, set_binom', ←Finset.powersetLen_map,Fin.map_valEmbedding_univ, Nat.Iio_eq_range]
 
--- set_binom n k is empty when k > n
-lemma set_binom_empty (n : ℕ) (k : ℕ) : (k > n) → set_binom n k = ∅ := by
-  intro h
-  simp [set_binom]
-  apply powersetLen_empty 
-  rw [card_range]
-  assumption
+/-- set_binom n k is empty when k > n -/
+lemma set_binom_empty {n k : ℕ} (h : n < k) : set_binom n k = ∅ := by
+  apply powersetLen_empty
+  rwa [card_range]
 
--- Elements of set_binom n k do not contain n.
-lemma set_binom_no_n (n : ℕ) (k : ℕ) (A: Finset ℕ) : A ∈ (set_binom n k) → ¬ n ∈ A := by
-  intro h
+/-- Elements of set_binom n k do not contain n. -/
+lemma set_binom_no_n {n k : ℕ} {A : Finset ℕ} (h : A ∈ set_binom n k) : ¬ n ∈ A := by
   simp [set_binom, mem_powersetLen] at h
   intro nA
   have nn : n ∈ range n := h.1 nA
-  have nn' : ¬ n ∈ range n := by simp 
-  contradiction
+  simp at nn
 
-
-/-- Pascal's identity in set form: $\binom{[n+1]}{k+1}$ is the *disjoint* union of $\binom{[n]}{k+1}$ and the image of $\binom{[n]}{k}$ under the insertion map $A \mapsto A \cup \{n\}$.  
+/-- Pascal's identity in set form: $\binom{[n+1]}{k+1}$ is the *disjoint* union of $\binom{[n]}{k+1}$ and the image of $\binom{[n]}{k}$ under the insertion map $A \mapsto A \cup \{n\}$.
 
 First, a proof of disjointness: -/
-def set_pascal_disjoint (n : ℕ) (k : ℕ) : Disjoint (set_binom n (k+1)) (image (insert n) (set_binom n k)) := (by
+lemma set_pascal_disjoint (n : ℕ) (k : ℕ) : Disjoint (set_binom n (k+1)) (image (insert n) (set_binom n k)) := by
   simp [disjoint_iff_ne]
-  intro A hA B hB hAB
-  clear hB
-  apply set_binom_no_n n (k+1) A hA
-  rw [hAB]
-  apply mem_insert_self
-  )
-
+  rintro A hA B - rfl
+  apply set_binom_no_n hA
+  simp
 
 -- Then, the set identity:
 theorem set_pascal (n : ℕ) (k : ℕ) : set_binom (n+1) (k+1) = disjUnion (set_binom n (k+1)) (image (insert n) (set_binom n k)) (set_pascal_disjoint n k) := by
-  simp [set_pascal_disjoint, set_binom, range, powersetLen_succ_insert] 
+  simp [set_pascal_disjoint, set_binom, range, powersetLen_succ_insert]
 
 
 -- To use this, also need the image (insert n) map to be injective on set_binom n k
-lemma insert_binom_inj (n : ℕ) (k : ℕ) : (∀ (A : Finset ℕ), A ∈ (set_binom n k) → ∀ (B : Finset ℕ), B ∈ (set_binom n k) → (insert n A = insert n B) → A = B) := by
-  intro A hA B hB hAB
-  rw [<-erase_insert (set_binom_no_n n k A hA), <-erase_insert (set_binom_no_n n k B hB), hAB]
+lemma insert_binom_inj (n : ℕ) (k : ℕ) :
+    ∀ A ∈ set_binom n k, ∀ B ∈ set_binom n k, insert n A = insert n B → A = B := by
+  rintro A hA B hB hAB
+  rw [← erase_insert (set_binom_no_n hA), ← erase_insert (set_binom_no_n hB), hAB]
 
 
 -- complement (in range n) is injective on set_binom n k
-lemma sdiff_binom_inj (n : ℕ) (k : ℕ) : (∀ (A : Finset ℕ), A ∈ (set_binom n k) → ∀ (B : Finset ℕ), B ∈ (set_binom n k) → (sdiff (range n) A = sdiff (range n) B) → A = B) := by
+lemma sdiff_binom_inj (n : ℕ) (k : ℕ) :
+    ∀ A ∈ set_binom n k, ∀ B ∈ set_binom n k, sdiff (range n) A = sdiff (range n) B → A = B := by
   intro A hA B hB hAB
   have hAn : range n \ (range n \ A) = A := by
     simp [set_binom, mem_powersetLen] at hA
@@ -113,41 +105,24 @@ lemma sdiff_binom_inj (n : ℕ) (k : ℕ) : (∀ (A : Finset ℕ), A ∈ (set_bi
   have hBn : range n \ (range n \ B) = B := by
     simp [set_binom, mem_powersetLen] at hB
     apply Finset.sdiff_sdiff_eq_self hB.1
-  rw [<- hAn, <- hBn]
-  congr
+  rw [← hAn, ← hBn, hAB]
 
 -- complement (in range n) maps set_binom n k to set_binom n (n-k) if k ≤ n
-lemma sdiff_binom_image (n : ℕ) (k : ℕ) (h : k ≤ n) : image (sdiff (range n)) (set_binom n k) = set_binom n (n-k) := by
+lemma sdiff_binom_image (n : ℕ) (k : ℕ) (h : k ≤ n) :
+    image (sdiff (range n)) (set_binom n k) = set_binom n (n-k) := by
   ext A
   simp [set_binom, mem_powersetLen]
   constructor
-  . intro h1
-    rcases h1 with ⟨ B, hB ⟩
-    rcases hB with ⟨ ⟨ hBn, cardB ⟩, sdiffB ⟩
-    rw [<- sdiffB]
+  . rintro ⟨B, ⟨hBn, cardB⟩, rfl⟩
     constructor
     . apply sdiff_subset
-    rw [card_sdiff hBn, card_range]
-    congr 
-  intro h1
-  rcases h1 with ⟨ hA, cardA ⟩
-  let B := sdiff (range n) A
-  use B
-  constructor
-  . constructor
-    .  apply sdiff_subset
-    rw [card_sdiff, card_range, cardA]
-    have h' : n = n - k + k := by
-      rw [Nat.sub_add_cancel h]
-    nth_rewrite 1 [h']
-    apply Nat.add_sub_cancel_left
-    assumption
-  have hAn : range n \ (range n \ A) = A := by
-    apply Finset.sdiff_sdiff_eq_self hA
-  assumption
-
-
-
-
-
-
+    · rw [card_sdiff hBn, card_range, cardB]
+  · rintro ⟨hA, cardA⟩
+    let B := sdiff (range n) A
+    use B
+    constructor
+    . constructor
+      . apply sdiff_subset
+      · rw [card_sdiff hA, card_range, cardA]
+        exact? says exact Nat.sub_sub_self h
+    · exact Finset.sdiff_sdiff_eq_self hA

--- a/SymmetricProject/esymm_basic.lean
+++ b/SymmetricProject/esymm_basic.lean
@@ -18,7 +18,7 @@ import SymmetricProject.binomial
 open Finset
 open BigOperators
 
-/-- "esymm n k" is the k^th elementary symmetric polynomial $S_{n,k}(x)$ in the first n of an infinite number $x_1, x_2, \dots$ of real variables.  
+/-- "esymm n k" is the k^th elementary symmetric polynomial $S_{n,k}(x)$ in the first n of an infinite number $x_1, x_2, \dots$ of real variables.
 
 We define this polynomial directly as a sum of monomials, instead of using MvPolynomial.esymm -/
 def esymm (n : ℕ) (k : ℕ) (x : ℕ → ℝ): ℝ := ∑ A in set_binom n k, (∏ i in A, x i)
@@ -33,10 +33,7 @@ lemma esymm_zero_eq_one (n : ℕ) (x : ℕ → ℝ) : esymm n 0 x = 1 := by
 -- S_{n,k}(x)=0 if k>n
 lemma esymm_eq_zero (n : ℕ) (k : ℕ) (x : ℕ → ℝ) : (k > n) → esymm n k x = 0 := by
   intro h
-  simp [esymm]
-  rw [set_binom_empty]
-  simp
-  exact h
+  simp [esymm, set_binom_empty h]
 
 
 -- S_{n,n}(x) = \prod_{i=0}^{n-1} x_i
@@ -47,8 +44,8 @@ lemma esymm_prod (n : ℕ) (x: ℕ → ℝ): esymm n n x = (∏ i in range n, x 
     congr
     exact (card_range n).symm
   rw [h]
-  apply sum_singleton 
-  
+  apply sum_singleton
+
 -- S_{n,k}(ax) = a^k S_{n,k}(x)
 lemma esymm_mul (n : ℕ) (k : ℕ) (x : ℕ → ℝ) (a : ℝ) : esymm n k (fun i => a * x i) = a^k * esymm n k x := by
   simp [esymm]
@@ -63,7 +60,7 @@ lemma esymm_mul (n : ℕ) (k : ℕ) (x : ℕ → ℝ) (a : ℝ) : esymm n k (fun
   tauto
 
 /-- If S_{n,n}(x) is non-zero, then
-$$ S_{n,k}(1/x) = S_{n,n-k}(x) / S_{n,n}(x) $$ 
+$$ S_{n,k}(1/x) = S_{n,n-k}(x) / S_{n,n}(x) $$
 for all 0 ≤ k ≤ n
 -/
 
@@ -87,19 +84,19 @@ lemma esymm_reflect (n : ℕ) (k : ℕ) (x : ℕ → ℝ) (h : esymm n n x ≠ 0
   nth_rewrite 2 [<- mul_one (∏ i in range n \ A, x i)]
   congr
   rw [<- prod_mul_distrib]
-  calc 
-    ∏ i in A, x i * (1 / x i) = ∏ i in A, 1 := by 
+  calc
+    ∏ i in A, x i * (1 / x i) = ∏ i in A, 1 := by
       apply prod_congr rfl
       intro i hia
       have hi' : i < n := by
         rw [<- mem_range]
         exact hAn hia
       exact mul_one_div_cancel (hi i hi')
-    _ = 1 := by 
+    _ = 1 := by
       exact prod_const_one
 
-  
-  
+
+
 /-- The Pascal identity for esymm:
 
 $$S_{n+1,k+1}(x) = S_{n,k+1}(x) + S_{n,k}(x) x_n$$
@@ -112,15 +109,15 @@ theorem esymm_pascal (n : ℕ) (k : ℕ) (x : ℕ → ℝ): esymm (n+1) (k+1) x 
   have h : X = esymm (n+1) (k+1) x := by rfl
   rw [esymm, set_pascal, sum_disjUnion (set_pascal_disjoint n k)] at h
   let monom := fun (A:Finset ℕ) => (∏ i in A, x i)
-    
+
   let W := ∑ A in image (insert n) (set_binom n k), monom A
 
-  have h2: X = Y + W := by 
+  have h2: X = Y + W := by
     rw [h]
     simp [esymm]
   rw [h2]
   congr
-  clear h h2 X Y 
+  clear h h2 X Y
 
   have h3 : W = ∑ A in (set_binom n k), monom (insert n A) := by
     apply sum_image
@@ -130,13 +127,13 @@ theorem esymm_pascal (n : ℕ) (k : ℕ) (x : ℕ → ℝ): esymm (n+1) (k+1) x 
   dsimp [esymm]
   rw [sum_mul]
   clear Z W monom h3
-  
+
   have h4 : ∀ A ∈ set_binom n k, ∏ i in insert n A, x i = (∏ i in A, x i) * x n := by
     intro A hA
-    rw [prod_insert (set_binom_no_n n k A hA)]
+    rw [prod_insert (set_binom_no_n hA)]
     ring
   rw [sum_congr rfl h4]
-  
+
 
 -- S_{n,1}(x) = \sum_{i=0}^{n-1} x_i
 lemma esymm_sum (n : ℕ) (x: ℕ → ℝ): esymm n 1 x = (∑ i in range n, x i) := by
@@ -144,4 +141,3 @@ lemma esymm_sum (n : ℕ) (x: ℕ → ℝ): esymm n 1 x = (∑ i in range n, x i
   . apply esymm_eq_zero 0 1 x (show 1 > 0 by norm_num)
   rw [(show 1 = 0+1 by norm_num), Nat.succ_eq_add_one, esymm_pascal m 0]
   rw [(show 0+1=1 by norm_num), ih, esymm_zero_eq_one m x, one_mul, sum_range_succ]
-  


### PR DESCRIPTION
As discussed on Zulip, those are local efficiency improvements on the first file of the project. Note in particular how implicit arguments allow to shorten lemma invocations by having Lean work more. Another recurring theme is using `rintro` or `rcases` in a more recursive way (this is what the  `r` in their name stands for) and use of the special name `rfl` which triggers an immediate substitution (this is explained at the end of the section about existential quantifiers in Mathematics in Lean).