### PR TITLE
add a positivity extension

### DIFF
--- a/SymmetricProject/jensen.lean
+++ b/SymmetricProject/jensen.lean
@@ -70,8 +70,6 @@ theorem new_inequality (n l : ℕ) (s : ℕ → ℝ) (r : ℝ) (h1: attainable n
 
     simp at h8
     simp [Real.zero_rpow h7, attainable_zero_eq_one h5, h8]
-    apply sum_nonneg
-    intro i _
     positivity
 
   have h7 : abs (s l) > 0 := by positivity

--- a/SymmetricProject/positivity_ext.lean
+++ b/SymmetricProject/positivity_ext.lean
@@ -1,0 +1,97 @@
+import Mathlib.Tactic.Positivity.Core
+import Mathlib.Algebra.BigOperators.Order
+
+/-!
+# Extensions to positivity
+
+To help it handle sums and products
+-/
+open Finset
+open BigOperators
+
+open Qq
+open Mathlib.Meta.Positivity Lean Meta
+
+@[positivity Finset.sum _ _] def evalSum : PositivityExt where eval {u β2} zβ pβ e := do
+  -- let ⟨v, l, r⟩ ← inferTypeQ' <| (Expr.getAppArgs (← withReducible (whnf e))).get! 1
+  let .app (.app (.app (.app (.app _ (β : Q(Type u))) (α : Q(Type u))) (_ : Q(AddCommMonoid $β)))
+    (s : Q(Finset $α))) (b : Q($α → $β)) ← withReducible (whnf e) | throwError "not sum"
+  haveI' : $β =Q $β2 := ⟨⟩
+  haveI' : $e =Q Finset.sum $s $b := ⟨⟩
+  let (lhs, _, (rhs : Q($β))) ← lambdaMetaTelescope b
+  let rb ← core zβ pβ rhs
+
+  let so : Option Q(Finset.Nonempty $s) ← do -- TODO if i make a typo it doesn't complain.?
+    try {
+      let _ ← synthInstanceQ (q(Fintype $α) : Q(Type u))
+      let _ ← synthInstanceQ (q(Nonempty $α) : Q(Prop))
+      match s with
+      | ~q(@univ _ $fi) => pure (some q(Finset.univ_nonempty (α := $α)))
+      | _ => pure none }
+    catch _ => do
+      let .some fv ← findLocalDeclWithType? q(Finset.Nonempty $s) | pure none
+      pure (some (.fvar fv))
+
+  match rb, so with
+  | .nonnegative pb, _ => do
+    let pα' ← synthInstanceQ (q(OrderedAddCommMonoid $β) : Q(Type u))
+    assertInstancesCommute
+    let pr : Q(∀ (i : $α), 0 ≤ $b i) ← mkLambdaFVars lhs pb
+    pure (.nonnegative q(@sum_nonneg.{u, u} $α $β $pα' $b $s (fun i _ => $pr i)))
+  | .positive pb, .some (fi : Q(Finset.Nonempty $s)) => do
+    let pα' ← synthInstanceQ (q(OrderedCancelAddCommMonoid $β) : Q(Type u))
+    assertInstancesCommute
+    let pr : Q(∀ (i : $α), 0 < $b i) ← mkLambdaFVars lhs pb
+    pure (.positive q(@sum_pos.{u, u} $α $β $pα' $b $s (fun i _ => $pr i) $fi))
+  | _, _ => pure .none
+
+
+/-- for now simply copy sum to prod version -/
+@[positivity Finset.prod _ _] def evalProd : PositivityExt where eval {u β2} zβ pβ e := do
+  -- let ⟨v, l, r⟩ ← inferTypeQ' <| (Expr.getAppArgs (← withReducible (whnf e))).get! 1
+  let .app (.app (.app (.app (.app _ (β : Q(Type u))) (α : Q(Type u))) (_ : Q(CommMonoid $β)))
+    (s : Q(Finset $α))) (b : Q($α → $β)) ← withReducible (whnf e) | throwError "not prod"
+  haveI' : $β =Q $β2 := ⟨⟩
+  haveI' : $e =Q Finset.prod $s $b := ⟨⟩
+  let (lhs, _, (rhs : Q($β))) ← lambdaMetaTelescope b
+  let rb ← core zβ pβ rhs
+
+  match rb with
+  | .nonnegative pb => do
+    let pα' ← synthInstanceQ (q(OrderedCommSemiring $β) : Q(Type u))
+    assertInstancesCommute
+    let pr : Q(∀ (i : $α), 0 ≤ $b i) ← mkLambdaFVars lhs pb
+    pure (.nonnegative q(@prod_nonneg.{u, u} $α $β $pα' $b $s (fun i _ => $pr i)))
+  | .positive pb => do
+    let pα' ← synthInstanceQ (q(StrictOrderedCommSemiring $β) : Q(Type u))
+    let pα'' ← synthInstanceQ (q(Nontrivial $β) : Q(Prop))
+    assertInstancesCommute
+    let pr : Q(∀ (i : $α), 0 < $b i) ← mkLambdaFVars lhs pb
+    pure (.positive q(@prod_pos.{u, u} $α $β $pα' $pα'' $b $s (fun i _ => $pr i)))
+  | _ => pure .none
+
+section tests
+
+/-
+set_option trace.Tactic.positivity true
+
+lemma oops (n : ℕ) (a : ℕ → ℤ): 0 ≤ ∑ j in range n, a j^2 := by
+  positivity
+
+#print axioms oops
+
+#check sum_pos
+
+lemma oops' (n : ℕ) (a : ℕ → ℤ): 0 ≤ ∑ j : Fin 8, ∑ i in range n, a j^2 + i ^ 2 := by
+  positivity
+
+
+lemma oops'' (n : ℕ) (a : ℕ → ℤ): 0 < ∑ j : Fin (n + 1), (a j^2 + 1) := by
+  positivity
+
+lemma oops''' (n : ℕ) (a : ℕ → ℤ): 0 < ∑ j in ({1} : Finset ℕ), (a j^2 + 1) := by
+  have : Finset.Nonempty {1} := singleton_nonempty 1
+  positivity
+
+-/
+end tests

--- a/SymmetricProject/prev_bound.lean
+++ b/SymmetricProject/prev_bound.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.MeanInequalities
 import SymmetricProject.esymm_basic
 import SymmetricProject.attainable
 import SymmetricProject.stirling
+import SymmetricProject.positivity_ext
 
 /- hack to avoid the real powers bug -/
 local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y)
@@ -43,13 +44,13 @@ lemma prelim_bound {n : ℕ} {s : ℕ → ℝ} (h1 : n > 2) (h2 : attainable n s
       simp
       . positivity
       . intro i _; positivity
-      . apply prod_nonneg; intro i _; positivity
+      . positivity
       . positivity
       . positivity
     _ ≤ (abs (∑ j in range n, x j^2) / n)^((2:ℝ)⁻¹) := by
       apply rpow_le_rpow
       . positivity
-      . rw [abs_prod, abs_of_nonneg (show (0:ℝ) ≤ ∑ j in range n, x j^2 by norm_cast; apply sum_nonneg; intro i _; positivity), <- finset_prod_rpow, sum_div]
+      . rw [abs_prod, abs_of_nonneg (by positivity), <- finset_prod_rpow, sum_div]
         have : ∑ j in range n, x j^2 / n = ∑ j in range n, ((n:ℝ)⁻¹)* |x j^2| := by
           congr
           ext j

--- a/SymmetricProject/stirling.lean
+++ b/SymmetricProject/stirling.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Data.Nat.Factorial.BigOperators
 import Init.Data.Nat.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import SymmetricProject.positivity_ext
 
 
 /- hack to avoid the real powers bug -/
@@ -36,8 +37,6 @@ lemma factorial_ge {n : ℕ} : n ! ≥ n^n / exp n := by
     _ ≥ (n:ℝ)^n/n ! := by
       rw [sum_range_succ]
       simp
-      apply sum_nonneg
-      intro k _
       positivity
   apply_fun (fun (X:ℝ) =>  X * (n ! / exp n)) at h
   . have h1 : (n !: ℝ) ≠ 0 := by positivity


### PR DESCRIPTION
I'll PR this to mathlib at some point, but @hrmacbeth suggested it might be nice to try it out "in the wild" first :)
Hope it is helpful, unfortunately it's not a silver bullet as several of your proofs still require some argument making use of the fact that the sum is over some specific positive elements rather than something positive for generic reasons, nevertheless it should be a step in the right direction (more automation!)