### PR TITLE
More rw_ineq

### DIFF
--- a/SymmetricProject/Tactic/RwIneq.lean
+++ b/SymmetricProject/Tactic/RwIneq.lean
@@ -9,8 +9,7 @@ def Lean.Expr.subst (target old new : Expr) : MetaM Expr := do
     return new
   else
     match target with
-  | Expr.app fn arg    => return (Expr.app (← fn.subst old new) (← arg.subst old new))
-
+    | Expr.app fn arg    => return (Expr.app (← fn.subst old new) (← arg.subst old new))
     | _                  => return target
 
 /-- Given expressions `orig : r a b` and `subst : s x y` for some relations
@@ -21,6 +20,15 @@ def Lean.Expr.substInRel (orig subst : Expr) : MetaM (Option Expr) := do
   let some (_rels, ls, rs) := (← getCalcRelation? subst) | return none
   return some (← mkAppM' relo #[ro, (← ro.subst ls rs)])
 
+/-- Given expressions `orig : r a b` and `subst : s x y` for some relations
+`r` and `s`, build the expression `r c a` where `c` is obtained from `a` by replacing
+any occurence of `y` in a function application argument by `x`. -/
+def Lean.Expr.substInRelRev (orig subst : Expr) : MetaM (Option Expr) := do
+  let some (relo, lo, _ro) := (← getCalcRelation? orig) | return none
+  let some (_rels, ls, rs) := (← getCalcRelation? subst) | return none
+  return some (← mkAppM' relo #[(← lo.subst rs ls), lo])
+
+
 def gcongrDefaultDischarger (g : MVarId) : MetaM PUnit :=Term.TermElabM.run' do
   let [] ← Tactic.run g <| evalTactic (Unhygienic.run `(tactic| gcongr_discharger)) | failure
 
@@ -29,19 +37,23 @@ where `c` is obtained from `b` by replacing any occurence of `x` in a function a
 by `y`. This new relation `h` is proven from `trans h h'` where `h' : r b c` is proven by `gcongr`
 using the list of given identifiers for newly introduced variables.
 Returns the list of new goals. -/
-def Lean.MVarId.rwIneq (g : MVarId) (h : Name) (subst : Expr)
+def Lean.MVarId.rwIneq (g : MVarId) (h : Name) (subst : Expr) (rev : Bool)
     (names : List (TSyntax ``binderIdent)) : MetaM (List MVarId) := do
   let decl ← (← getLCtx).findFromUserName? h
-  let some newIneq := ← Lean.Expr.substInRel decl.type subst
+  let substFun := if rev then Lean.Expr.substInRelRev else Lean.Expr.substInRel
+  let some newIneq ← substFun decl.type subst
     | throwError "Could not create the new relation."
   let mvar ← mkFreshExprMVar newIneq
   let (success, _, newGoals) ← mvar.mvarId!.gcongr none names gcongrDefaultDischarger
   if success then
     let g ← g.clear decl.fvarId
-    let (_, newGoal) ← g.note decl.userName (← mkAppM `Trans.trans #[.fvar decl.fvarId, mvar])
+    let transArgs := if rev then #[mvar, .fvar decl.fvarId] else #[.fvar decl.fvarId, mvar]
+    let (_, newGoal) ← g.note decl.userName (← mkAppM `Trans.trans transArgs)
     return newGoal::newGoals.toList
   else
     throwError "The `gcongr` tactic called by `rw_ineq` failed."
+
+open Lean Parser Tactic
 
 /-- `rw_ineq e at h` rewrite in the relation assumption `h : r a b` using `e : s x y` to replace `h`
 with `r a c` where `c` is obtained from `b` by replacing any occurence of `x` in a function
@@ -56,12 +68,14 @@ example (x y z w u : ℝ) (bound : x * exp y ≤ z + exp w) (h : w ≤ u) :  x *
   exact bound
 ```
 -/
-elab "rw_ineq" e:term "at " h:ident withArg:((" with " (colGt binderIdent)+)?) : tactic =>
+elab tok:"rw_ineq" rules:rwRuleSeq "at " h:ident withArg:((" with " (colGt binderIdent)+)?) : tactic =>
   withMainContext do
-  let mainGoal ← getMainGoal
-  let subst ← inferType (← Lean.Elab.Term.elabTerm e none)
-  let names := (withArg.raw[1].getArgs.map TSyntax.mk).toList
-  replaceMainGoal (← mainGoal.rwIneq h.getId subst names)
+  withRWRulesSeq tok rules fun symm term => do
+    let mainGoal ← getMainGoal
+    mainGoal.withContext do
+    let subst ← inferType (← Lean.Elab.Term.elabTerm term none)
+    let names := (withArg.raw[1].getArgs.map TSyntax.mk).toList
+    replaceMainGoal (← mainGoal.rwIneq h.getId subst symm names)
 
 /-- `rwa_ineq e at h` rewrite in the relation assumption `h : r a b` using `e : s x y` to replace `h`
 with `r a c` where `c` is obtained from `b` by replacing any occurence of `x` in a function
@@ -75,28 +89,33 @@ example (x y z w u : ℝ) (bound : x * exp y ≤ z + exp w) (h : w ≤ u) :  x *
   rwa_ineq h at bound
 ```
 -/
-elab "rwa_ineq" e:term "at " h:ident withArg:((" with " (colGt binderIdent)+)?) : tactic =>
+elab tok:"rwa_ineq" rules:rwRuleSeq "at " h:ident withArg:((" with " (colGt binderIdent)+)?) : tactic =>
   withMainContext do
-  let mainGoal ← getMainGoal
-  let subst ← inferType (← Lean.Elab.Term.elabTerm e none)
-  let names := (withArg.raw[1].getArgs.map TSyntax.mk).toList
-  replaceMainGoal (← mainGoal.rwIneq h.getId subst names)
+  withRWRulesSeq tok rules fun symm term => do
+    let mainGoal ← getMainGoal
+    mainGoal.withContext do
+    let subst ← inferType (← Lean.Elab.Term.elabTerm term none)
+    let names := (withArg.raw[1].getArgs.map TSyntax.mk).toList
+    replaceMainGoal (← mainGoal.rwIneq h.getId subst symm names)
   (← getMainGoal).assumption
 
 open Real
 
 example (x y z w u : ℝ) (bound : x * exp y ≤ z + 2*exp w) (h : w ≤ u) :
     x * exp y ≤ z + 2*exp u := by
-  rw_ineq h at bound
+  rw_ineq [h] at bound
   exact bound
 
 example (x y z w u : ℝ) (bound : x * exp y < z + 2*exp w) (h : w < u) :
     x * exp y < z + 2*exp u := by
-  rwa_ineq h at bound
+  rwa_ineq [h] at bound
 
 -- Test where a side condition is not automatically discharged.
 example (x y z w u : ℝ) (bound : x * exp y < z + x^2*exp w) (h : w < u) (hx : 2*x > 2) :
     x * exp y < z + x^2*exp u := by
-  rwa_ineq h at bound
+  rwa_ineq [h] at bound
   apply pow_pos
   linarith
+
+example {a b c d : ℝ} (bound : a + b ≤ c + d) (h : c ≤ 2) (k : 1 ≤ a) : 1 + b ≤ 2 + d := by
+  rwa_ineq [h, ← k] at bound

--- a/SymmetricProject/main.lean
+++ b/SymmetricProject/main.lean
@@ -368,10 +368,10 @@ theorem uniform_bound : ∃ C : ℝ, ∀ N : ℕ, 1 ≤ N → best_constant N �
     rcases bound with bound | bound
     . replace bound := ineq_comb bound h6' (by positivity) (by positivity)
       rw [lem1, <-rpow_neg_one (best_constant N), <- rpow_add, lem2, one_mul, lem3, <- inv_rpow _ 2⁻¹, inv_div] at bound
-      rw_ineq hN' at bound
+      rw_ineq [hN'] at bound
       have : ((k:ℝ)+1)/n ≤ 1 := by
         rw [le_div_iff]; norm_cast; positivity
-      rw_ineq this at bound
+      rw_ineq [this] at bound
 
       sorry
     sorry

--- a/Test/test.lean
+++ b/Test/test.lean
@@ -12,6 +12,6 @@ open Real
 open Nat
 
 example {a b c d e: ℝ} (h: a ≤ (Real.exp c)*b) (h1 : c ≤ 1) : false := by
-  rw_ineq h1 at h
-  
+  rw_ineq [h1] at h
+
   sorry

--- a/Test/test_old.lean
+++ b/Test/test_old.lean
@@ -12,7 +12,7 @@ open Real
 open Nat
 
 example {a b c d e: ℝ} (h: a*b ≤ c*(Real.exp e)*d) (h1 : e ≤ 1) : false := by
-  rw_ineq h1 at h
+  rw_ineq [h1] at h
   sorry
 
 


### PR DESCRIPTION
Handle sequences and right to left in `rw_ineq` as discussed on Zulip. Also stay closer to the `rw` syntax by putting square brackets in all cases.