### PR TITLE
Fix Newton identity range and lem9 comment delimiters

### DIFF
--- a/LaTeX/symmetric.tex
+++ b/LaTeX/symmetric.tex
@@ -83,7 +83,7 @@ We call a $n+1$-tuple $(s_0,\dots,s_n)$ of real numbers \emph{attainable} if it 
 
 
 
-\begin{proposition}[Newton's inequality]\label{prop-newton} If $(s_0,\dots,s_n)$ is attainable, then $s_k s_{k+2} \leq s_{k+1}^2$ for all $0 \leq k \leq n$.
+\begin{proposition}[Newton's inequality]\label{prop-newton} If $(s_0,\dots,s_n)$ is attainable, then $s_k s_{k+2} \leq s_{k+1}^2$ for all $0 \leq k \leq n-2$.
 \end{proposition}
 
 We now prove

--- a/SymmetricProject/main_lemmas.lean
+++ b/SymmetricProject/main_lemmas.lean
@@ -347,7 +347,7 @@ lemma lem9g {k m n N : ℕ} {A : ℝ} {s : ℕ → ℝ} (h1: k > 10) (h2 : 0 < m
     simp at h4; linarith
   all_goals positivity
 
--- The main calculation needed to establish (4.7) -/
+/- The main calculation needed to establish (4.7) -/
 lemma lem9 {k m n N : ℕ} {A : ℝ} {s : ℕ → ℝ} (h1: k > 10) (h2 : 0 < m) (h3 : m < k) (h4 : k+2 ≤ n) (h5 : n ≤ N) (hA: 1 ≤ A) (hk : 3 * k < 2 * n) (bound: |s m| ^ ((n:ℝ) - m)⁻¹ ≤ max (A ^ (((k:ℝ) - ↑m) / ((n:ℝ) - k)) * (((n:ℝ) - m) / ((k:ℝ) - m)) ^ (((k:ℝ) - m) / (2 * ((n:ℝ) - k))) * |s k| ^ ((n:ℝ) - k)⁻¹) (A ^ (((k:ℝ) + 1 - m) / ((n:ℝ) - ((k:ℝ) + 1))) *(((n:ℝ) - m) / ((k:ℝ) + 1 - m)) ^ (((k:ℝ) + 1 - m) / (2 * ((n:ℝ) - (k + 1)))) * |s (k + 1)| ^ ((n:ℝ) - (k + 1))⁻¹)) (h6: (n/k)^2⁻¹ * |s k|^k⁻¹ ≤ A⁻¹ * rexp N⁻¹) (h6': (n/(k+1))^2⁻¹ * |s (k+1)|^(k+1)⁻¹ ≤ A⁻¹ * rexp N⁻¹) : (Nat.choose n m) * |s m| ≤ (rexp 7 * (k+1) / (A * m)) ^ m * (n/(k+1))^(m/2) := by
   replace bound := lem9g h1 h2 h3 h4 h5 hA hk bound h6 h6'
   clear N h5 h6 h6'


### PR DESCRIPTION
## Summary
- Correct the documented Newton range to `k ≤ n-2` where the identity applies.
- Fix `lem9` comment delimiters (`-- … -/` → `/- … -/`).

## Test plan
- [ ] CI / lake build