### PR TITLE
build: include entropy/entropy_basic in the Lake package

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -12,3 +12,8 @@ require mathlib from git
 lean_lib «SymmetricProject» {
   -- add any library configuration options here
 }
+
+/-- Entropy helpers live under `entropy/` rather than `SymmetricProject/`. -/
+lean_lib Entropy where
+  roots := #[`entropy.entropy_basic]
+


### PR DESCRIPTION
## Summary
- `entropy/entropy_basic.lean` lived outside `SymmetricProject/` and was not part of any library target
- Add an `Entropy` Lake lib so it builds with the package

## Test plan
- [x] `lakefile.lean` declares `lean_lib Entropy` with root `entropy.entropy_basic`
- [ ] `lake build Entropy` includes the module